### PR TITLE
integrate playwright and implement persistent screenshots

### DIFF
--- a/health_check.py
+++ b/health_check.py
@@ -131,7 +131,7 @@ def get_screenshots(url_list, output_dir):
     timestamp = datetime.datetime.now().strftime('%Y-%m-%dT%H.%M.%S')
     path = Path(output_dir) / timestamp
     path.mkdir(parents=True)
-    coro = playwright_workflow.main(path)
+    coro = playwright_workflow.generate_screenshots(path)
     asyncio.run(coro)
     return path
 

--- a/health_check.py
+++ b/health_check.py
@@ -7,13 +7,16 @@ import shutil
 import smtplib
 import socket
 import time
+import asyncio
 from argparse import Namespace
 from email.message import EmailMessage
+from pathlib import Path
 
 import requests
 from slack_sdk import WebClient
 from slack_sdk.webhook import WebhookClient
-from webscreenshot.webscreenshot import take_screenshot
+
+import playwright_workflow
 
 
 def health_check(server=None, timeout=10.0):
@@ -125,44 +128,12 @@ def post_slack_message(subject, content, test=False):
 
 def get_screenshots(url_list, output_dir):
 
-    shutil.rmtree(output_dir, ignore_errors=True)
-
-    options = Namespace(
-        URL=None,
-        ajax_max_timeouts="5000,10000",
-        cookie=None,
-        crop=None,
-        custom_js=None,
-        format="png",
-        header=None,
-        http_password=None,
-        http_username=None,
-        imagemagick_binary=None,
-        input_file=None,
-        label=False,
-        label_bg_color="NavajoWhite",
-        label_size=60,
-        log_level="DEBUG",
-        multiprotocol=False,
-        no_error_file=False,
-        no_xserver=True,
-        output_directory=output_dir,
-        port=None,
-        proxy=None,
-        proxy_auth=None,
-        proxy_type=None,
-        quality=75,
-        renderer="phantomjs",
-        renderer_binary=None,
-        single_output_file=None,
-        ssl=False,
-        timeout="60",
-        verbosity=2,
-        window_size="1200,800",
-        workers=4,
-    )
-
-    take_screenshot(url_list=url_list, options=options)
+    timestamp = datetime.datetime.now().strftime('%Y-%m-%dT%H.%M.%S')
+    path = Path(output_dir) / timestamp
+    path.mkdir(parents=True)
+    coro = playwright_workflow.main(path)
+    asyncio.run(coro)
+    return path
 
 
 def upload_files_to_slack(files):
@@ -204,7 +175,7 @@ def _to_json(statuses):
 
 def main(test=True):
     servers = [
-        "https://raydata.nsls2.bnl.gov/raydata/",
+        # "https://raydata.nsls2.bnl.gov/raydata/",
         "http://127.0.0.1:8081/raydata",
         # "https://expdev-test.nsls2.bnl.gov/srw#/simulations",
         # "https://expdev.nsls2.bnl.gov/srw#/simulations",
@@ -356,11 +327,11 @@ def main(test=True):
         # send_status_email(subject, addressees, '\n'.join(msgs), test=test)
         post_slack_message(subject, "\n".join(msgs), test=test)
 
-        output_dir = "/tmp/sirepo-healthcheck-screenshots"
+        output_dir = "/tmp/hw-sirepo-healthcheck-screenshots"
 
-        get_screenshots(url_list=servers, output_dir=output_dir)
+        output_subdir = get_screenshots(url_list=servers, output_dir=output_dir)
 
-        files = glob.glob(os.path.join(output_dir, "*.png"))
+        files = glob.glob(os.path.join(output_subdir, "*.png"))
         upload_files_to_slack(files)
 
 

--- a/playwright_workflow.py
+++ b/playwright_workflow.py
@@ -11,6 +11,7 @@ import datetime
 import os
 import re
 from playwright.async_api import async_playwright, expect
+from pathlib import Path
 
 BASE_URL = "http://127.0.0.1:8081/raydata"
 
@@ -57,7 +58,7 @@ if __name__ == "__main__":
 
     import argparse
     parser = argparse.ArgumentParser()
-    parser.add_argument("OUTPUT_DIR")
+    parser.add_argument("-o", "--output-dir", type=Path, default=".", help="Path to save screenshots", dest="OUTPUT_DIR")
     args = parser.parse_args()
     asyncio.run(generate_screenshots(args.OUTPUT_DIR))
 

--- a/playwright_workflow.py
+++ b/playwright_workflow.py
@@ -1,0 +1,63 @@
+"""
+Check https://playwright.dev/python/docs/intro for more info.
+
+$ pip install playwright
+$ playwright install
+$ python playwright-test.py
+
+"""
+import asyncio
+import datetime
+import os
+import re
+from itertools import count
+from playwright.async_api import async_playwright, expect
+
+BASE_URL = "http://127.0.0.1:8081/raydata"
+
+
+def log_msg(msg):
+    print(f"{datetime.datetime.now().isoformat()} {msg}")
+
+
+async def main(output_dir):
+    async with async_playwright() as p:
+        counter = count()
+        log_msg("Launch a browser")
+        browser = await p.chromium.launch(headless=True)
+        page = await browser.new_page()
+        page.set_default_timeout(timeout=60_000)  # in milliseconds
+
+        log_msg(f"Go to {BASE_URL}")
+        await page.goto(BASE_URL)
+
+        await expect(page).to_have_title(re.compile("Raydata"))
+
+        await expect(page.get_by_role("link", name="Examples", exact=True)).to_be_visible()
+
+        log_msg("Taking a screenshot")
+        await page.screenshot(path=f"{output_dir}/screenshot-{next(counter):02d}.png", full_page=True)
+
+        await page.get_by_role("link", name="Examples", exact=True).click()
+
+        log_msg("Taking a screenshot")
+        await page.screenshot(path=f"{output_dir}/screenshot-{next(counter):02d}.png", full_page=True)
+
+        await expect(page.get_by_role("link", name="CHX Analysis", exact=True)).to_be_visible()
+        await page.get_by_role("link", name="CHX Analysis", exact=True).click()
+
+        log_msg("Taking a screenshot")
+        await page.screenshot(path=f"{output_dir}/screenshot-{next(counter):02d}.png", full_page=True)
+
+        log_msg("Close the browser")
+        await browser.close()
+
+
+if __name__ == "__main__":
+
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("OUTPUT_DIR")
+    args = parser.parse_args()
+    asyncio.run(main(args.OUTPUT_DIR))
+

--- a/playwright_workflow.py
+++ b/playwright_workflow.py
@@ -10,7 +10,6 @@ import asyncio
 import datetime
 import os
 import re
-from itertools import count
 from playwright.async_api import async_playwright, expect
 
 BASE_URL = "http://127.0.0.1:8081/raydata"
@@ -20,13 +19,14 @@ def log_msg(msg):
     print(f"{datetime.datetime.now().isoformat()} {msg}")
 
 
-async def main(output_dir):
+async def generate_screenshots(output_dir):
     async with async_playwright() as p:
-        counter = count()
         log_msg("Launch a browser")
         browser = await p.chromium.launch(headless=True)
         page = await browser.new_page()
         page.set_default_timeout(timeout=60_000)  # in milliseconds
+        timestamp = lambda: datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+        unique_filepath = lambda name="image": (f"{output_dir}/screenshot-{timestamp()}-{name}.png")
 
         log_msg(f"Go to {BASE_URL}")
         await page.goto(BASE_URL)
@@ -36,18 +36,18 @@ async def main(output_dir):
         await expect(page.get_by_role("link", name="Examples", exact=True)).to_be_visible()
 
         log_msg("Taking a screenshot")
-        await page.screenshot(path=f"{output_dir}/screenshot-{next(counter):02d}.png", full_page=True)
+        await page.screenshot(path=unique_filepath("home_page"), full_page=True)
 
         await page.get_by_role("link", name="Examples", exact=True).click()
 
         log_msg("Taking a screenshot")
-        await page.screenshot(path=f"{output_dir}/screenshot-{next(counter):02d}.png", full_page=True)
+        await page.screenshot(path=unique_filepath("examples_page"), full_page=True)
 
         await expect(page.get_by_role("link", name="CHX Analysis", exact=True)).to_be_visible()
         await page.get_by_role("link", name="CHX Analysis", exact=True).click()
 
         log_msg("Taking a screenshot")
-        await page.screenshot(path=f"{output_dir}/screenshot-{next(counter):02d}.png", full_page=True)
+        await page.screenshot(path=unique_filepath("CHX_analysis_page"), full_page=True)
 
         log_msg("Close the browser")
         await browser.close()
@@ -59,5 +59,5 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("OUTPUT_DIR")
     args = parser.parse_args()
-    asyncio.run(main(args.OUTPUT_DIR))
+    asyncio.run(generate_screenshots(args.OUTPUT_DIR))
 


### PR DESCRIPTION
This PR integrates a playwright screenshot workflow with health_check.py and implements a mechanism to persist screenshots.

Following screenshot demonstrates the results of a test ran on raydata under user account, together with a test slack workspace.

![Screenshot from 2023-08-05 00-02-49](https://github.com/NSLS-II/sirepo-healthcheck/assets/25692496/78cd556c-4d6d-4848-8654-19d1bf23580a)

Finally, here is an example demonstrating persistent screenshots (collected during testing):

![Screenshot from 2023-08-05 00-05-14](https://github.com/NSLS-II/sirepo-healthcheck/assets/25692496/0dca39a4-9846-473f-9340-654452d04518)
